### PR TITLE
Ask yes or no instead of cancel or abort

### DIFF
--- a/src/NativeBOINC/res/values/strings.xml
+++ b/src/NativeBOINC/res/values/strings.xml
@@ -725,7 +725,7 @@ Choose \'Yes\' if you only want to use NativeBOINC as BOINC manager.</string>
 	<string name="eventAttachedProjectMessage">Project from %s was attached</string>
 	<string name="eventDetachedProject">Project was detached</string>
 	<string name="eventDetachedProjectMessage">Project from %s was detached</string>
-	<string name="eventBencharkRun">Benchmark was ran</string>
+	<string name="eventBencharkRun">Benchmark was started</string>
 	<string name="eventBencharkFinished">Benchmark was finished</string>
 	<string name="eventSuspendAll">All tasks were suspended</string>
 	<string name="eventRunTasks">Tasks were resumed</string>

--- a/src/NativeBOINC/src/sk/boinc/nativeboinc/TasksActivity.java
+++ b/src/NativeBOINC/src/sk/boinc/nativeboinc/TasksActivity.java
@@ -503,7 +503,7 @@ public class TasksActivity extends ListActivity implements ClientUpdateTasksRece
 	    		.setIcon(android.R.drawable.ic_dialog_alert)
 	    		.setTitle(R.string.warning)
 				.setView(LayoutInflater.from(this).inflate(R.layout.dialog, null))
-	    		.setPositiveButton(R.string.taskAbort,
+	    		.setPositiveButton(R.string.yesText,
 	    			new DialogInterface.OnClickListener() {
 	    				public void onClick(DialogInterface dialog, int whichButton) {
 	    					//TaskInfo task = (TaskInfo)getListAdapter().getItem(mPosition);
@@ -522,7 +522,7 @@ public class TasksActivity extends ListActivity implements ClientUpdateTasksRece
 	    								mSelectedTasks.toArray(new TaskDescriptor[0]));
 	    				}
 	    			})
-	    		.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+	    		.setNegativeButton(R.string.noText, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						onDismissWarnAbortDialog();

--- a/src/NativeBOINC/src/sk/boinc/nativeboinc/TransfersActivity.java
+++ b/src/NativeBOINC/src/sk/boinc/nativeboinc/TransfersActivity.java
@@ -477,7 +477,7 @@ public class TransfersActivity extends ListActivity implements ClientUpdateTrans
 	    		.setIcon(android.R.drawable.ic_dialog_alert)
 	    		.setTitle(R.string.warning)
 				.setView(LayoutInflater.from(this).inflate(R.layout.dialog, null))
-	    		.setPositiveButton(R.string.transferAbort,
+	    		.setPositiveButton(R.string.yesText,
 	    			new DialogInterface.OnClickListener() {
 	    				public void onClick(DialogInterface dialog, int whichButton) {
 	    					onDismissWarnAbortDialog();
@@ -494,7 +494,7 @@ public class TransfersActivity extends ListActivity implements ClientUpdateTrans
 	    								mSelectedTransfers.toArray(new TransferDescriptor[0]));
 	    				}
 	    			})
-	    		.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+	    		.setNegativeButton(R.string.noText, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						onDismissWarnAbortDialog();


### PR DESCRIPTION
Abort and cancel are almost the same and in German they are both translated to the same word "abbrechen", so it might be better to ask yes or no, because it is confusing to have two buttons with the same text, but causing different actions.
